### PR TITLE
Added ability to search on partial names of application

### DIFF
--- a/src/NowApplications.ts
+++ b/src/NowApplications.ts
@@ -34,7 +34,16 @@ export class NowApplications {
     }
 
     findBy(pred:string, value:any) {
-        return _.find(this._applications, [pred,value]);
+         //prioritize exact matches
+         let key = _.find(this._applications, function(app){
+            return app[pred].toString().toLowerCase() === value.toString().toLowerCase();
+        });
+        if(!key){
+            key = _.find(this._applications, function(app){
+                return app[pred].toString().toLowerCase().indexOf(value.toString().toLowerCase()) > -1;
+            });
+        }
+        return key;
     }
 
     static getNowApplications(): NowApplications {


### PR DESCRIPTION
This gives the `set app` command the ability to match on partial app names. In the past only an exact match would do. 

Example: If I had an app called testsync
__Before Change__
```
set app test
```
This would fail

__After Change__
```
set app test
```
will set the application to the first match containing that string, in this case it would be testsync

Exact matches are still supported so no functionality should be lost.