### PR TITLE
Added file push debounce for linux compatibility

### DIFF
--- a/src/NowFile.ts
+++ b/src/NowFile.ts
@@ -370,7 +370,9 @@ export class NowFile {
                         }`
                 );
                 NowFile.debug.log(`  ${this._fileName}`);
-                this.pushFile();
+                //debounce the file push
+                let pushFile = this.pushFile.bind(this);
+                setTimeout(pushFile,100);
                 break;
             case Sync.PULL:
             case Sync.INSTANCE:


### PR DESCRIPTION
This change is simple but effective. It adds a small debounce to the file push to allow the filesystem to settle before trying to read the contents of a file. This makes file pushing on Linux __much__ more reliable.